### PR TITLE
chore(security): return early for unused modules

### DIFF
--- a/src/core_plugins/console/index.js
+++ b/src/core_plugins/console/index.js
@@ -11,6 +11,10 @@ import {
 } from './server';
 
 export default function (kibana) {
+
+  // PERCH: EARLY RETURN, ENSURE RESTRICTED
+  return;
+
   const modules = resolve(__dirname, 'public/webpackShims/');
   const src = resolve(__dirname, 'public/src/');
 

--- a/src/core_plugins/elasticsearch/index.js
+++ b/src/core_plugins/elasticsearch/index.js
@@ -124,9 +124,9 @@ module.exports = function ({ Plugin }) {
       createProxy(server, 'GET', '/{paths*}');
       createProxy(server, 'POST', '/_mget');
       createProxy(server, 'POST', '/{index}/_search');
-      createProxy(server, 'POST', '/{index}/_field_stats');
+      //createProxy(server, 'POST', '/{index}/_field_stats');
       createProxy(server, 'POST', '/_msearch');
-      createProxy(server, 'POST', '/_search/scroll');
+      //createProxy(server, 'POST', '/_search/scroll');
 
       function noBulkCheck({ path }, reply) {
         if (/\/_bulk/.test(path)) {
@@ -155,7 +155,8 @@ module.exports = function ({ Plugin }) {
       // destroying the kibana index, so we limit that ability here.
       createProxy(
         server,
-        ['PUT', 'POST', 'DELETE'],
+        //['PUT', 'POST', 'DELETE'],
+        ['POST'],
         `/${kibanaIndex}/{paths*}`,
         {
           pre: [ noDirectIndex, noBulkCheck ]

--- a/src/core_plugins/kibana/index.js
+++ b/src/core_plugins/kibana/index.js
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import Promise from 'bluebird';
 import { mkdirp as mkdirpNode } from 'mkdirp';
 
-import manageUuid from './server/lib/manage_uuid';
+//import manageUuid from './server/lib/manage_uuid';
 //import ingest from './server/routes/api/ingest';
 import search from './server/routes/api/search';
 //import settings from './server/routes/api/settings';
@@ -144,7 +144,7 @@ module.exports = function (kibana) {
 
     init: function (server) {
       // uuid
-      manageUuid(server);
+      //manageUuid(server);
       // routes
       //ingest(server);
       search(server);

--- a/src/core_plugins/metrics/index.js
+++ b/src/core_plugins/metrics/index.js
@@ -2,6 +2,10 @@ import fieldsRoutes from './server/routes/fields';
 import visDataRoutes from './server/routes/vis';
 
 export default function (kibana) {
+
+  // PERCH: EARLY RETURN, ENSURE RESTRICTED
+  return;
+
   return new kibana.Plugin({
     require: ['kibana','elasticsearch'],
 

--- a/src/core_plugins/spy_modes/index.js
+++ b/src/core_plugins/spy_modes/index.js
@@ -1,4 +1,8 @@
 export default function (kibana) {
+
+  // PERCH: EARLY RETURN, ENSURE RESTRICTED
+  return;
+
   return new kibana.Plugin({
     uiExports: {
       spyModes: [

--- a/src/core_plugins/timelion/index.js
+++ b/src/core_plugins/timelion/index.js
@@ -1,5 +1,8 @@
 
 module.exports = function (kibana) {
+  // PERCH: EARLY RETURN, ENSURE RESTRICTED
+  return;
+
   let mainFile = 'plugins/timelion/app';
 
   const ownDescriptor = Object.getOwnPropertyDescriptor(kibana, 'autoload');


### PR DESCRIPTION
- this is mostly just an extra precaution to ensure unused modules are not run