### PR TITLE
CHORE: add Sentry error tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@kbn/pm": "link:packages/kbn-pm",
     "@kbn/test-subj-selector": "link:packages/kbn-test-subj-selector",
     "@kbn/ui-framework": "link:packages/kbn-ui-framework",
+    "@sentry/node": "4.5.1",
     "JSONStream": "1.1.1",
     "abortcontroller-polyfill": "^1.1.9",
     "angular": "1.6.9",

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -21,6 +21,7 @@ import _ from 'lodash';
 import { pkg } from '../utils';
 import Command from './command';
 import serveCommand from './serve/serve';
+import wrapKibanaCli from './perch';
 
 const argv = process.env.kbnWorkerArgv ? JSON.parse(process.env.kbnWorkerArgv) : process.argv.slice();
 const program = new Command('bin/kibana');
@@ -61,4 +62,6 @@ if (!subCommand) {
   }
 }
 
-program.parse(argv);
+wrapKibanaCli(program).then(() => {
+  program.parse(argv);
+});

--- a/src/cli/perch.js
+++ b/src/cli/perch.js
@@ -1,0 +1,82 @@
+/* eslint-disable @kbn/license-header/require-license-header */
+/// <reference path="./command.js" />
+import os from 'os';
+
+import Wreck from 'wreck';
+
+
+/**
+ * EC2 instance ID or local hostname, depending on availability.
+ * See beforeKibanaStart
+ *
+ * @type {String}
+ */
+let serverName;
+
+
+/**
+ *
+ * @param {Command} program The commander Command instance used to initialize
+ *                          the Kibana CLI
+ * @return {Promise<void>}
+ */
+export default async function wrapKibanaCli(program) {
+  const serve = program.commands.find(command => command.name() === 'serve');
+  const parent = serve.parent || serve;
+  const name = parent === serve ? '*' : serve.name();
+  parent.prependListener(name, beforeKibanaServerStart);
+
+  return beforeKibanaStart();
+}
+
+
+/**
+ * Called before command-line arguments are parsed and executed
+ *
+ * @return {Promise<void>}
+ */
+export async function beforeKibanaStart() {
+  return (
+    Wreck.get(
+      'http://instance-data/latest/meta-data/instance-id',
+      { timeout: 10 }
+    ).then(
+      (err, resp, payload) => {
+        // We're on an EC2 instance; use the instance ID for server name
+        serverName = payload;
+      },
+      () => {
+        // We're outside AWS, perhaps in a dev env; use standard hostname
+        serverName = os.hostname();
+      }
+    ).then(() => {
+      enableSentryErrorTracking();
+    })
+  );
+}
+
+
+/**
+ * Called right before the Kibana server starts.
+ */
+export function beforeKibanaServerStart() {
+
+}
+
+
+/**
+ * Initialize sentry error tracking
+ */
+export function enableSentryErrorTracking(...clientOptions) {
+  const Sentry = require('@sentry/node');
+  Sentry.init({
+    dsn: 'https://6e4861a4495b4b3eb0981bba1f2c6524@sentry.io/1367239',
+    environment: process.env.APP_ENV || 'DEV',
+    serverName,
+    ...clientOptions,
+  });
+
+  const client = Sentry.getCurrentHub().getClient();
+  const finalOptions = client.options;
+  console.info(`Initialized Sentry with options: ${JSON.stringify(finalOptions)}`);
+}

--- a/src/core_plugins/elasticsearch/index.js
+++ b/src/core_plugins/elasticsearch/index.js
@@ -26,9 +26,7 @@ import { createAdminCluster } from './lib/create_admin_cluster';
 import { clientLogger } from './lib/client_logger';
 import { createClusters } from './lib/create_clusters';
 import filterHeaders from './lib/filter_headers';
-
-//import createProxy from './lib/create_proxy';
-import { createProxy, createPath, proxyHandler } from './lib/perch_create_proxy';
+import { createProxy, proxyHandler } from './lib/perch_create_proxy';
 
 const DEFAULT_REQUEST_HEADERS = [ 'authorization' ];
 

--- a/src/core_plugins/elasticsearch/lib/perch_create_proxy.js
+++ b/src/core_plugins/elasticsearch/lib/perch_create_proxy.js
@@ -1,3 +1,4 @@
+/* eslint-disable @kbn/license-header/require-license-header */
 /*
 This file is a custom perch security written replacement for create_proxy.js.
 It was created because there was no way to monkey patch create_proxy and hook into the ES request to set the user's allowed companies for all requests.
@@ -5,7 +6,6 @@ It is mostly a mashup of these two files:
 https://github.com/elastic/kibana/blob/5.4/src/core_plugins/elasticsearch/lib/create_proxy.js
 https://github.com/hapijs/h2o2/blob/master/lib/index.js
 */
-import createAgent from './create_agent';
 import mapUri from './map_uri';
 import Wreck from 'wreck';
 import Hoek from 'hoek';
@@ -16,20 +16,6 @@ export function createProxy(server, method, path, config) {
   const proxies = new Map([
     ['/elasticsearch', server.plugins.elasticsearch.getCluster('data')],
   ]);
-
-  const responseHandler = function (err, upstreamResponse, request, reply) {
-    if (err) {
-      reply(err);
-      return;
-    }
-
-    if (upstreamResponse.headers.location) {
-      // TODO: Workaround for #8705 until hapi has been updated to >= 15.0.0
-      upstreamResponse.headers.location = encodeURI(upstreamResponse.headers.location);
-    }
-
-    reply(null, upstreamResponse);
-  };
 
   for (const [proxyPrefix, cluster] of proxies) {
     const options = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,6 +277,65 @@
   dependencies:
     url-pattern "^1.0.3"
 
+"@sentry/core@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-4.5.1.tgz#bfc98a276974a670e25ca5873ba7ac078bf5410d"
+  integrity sha512-ml4Z1PZ7GjsJip5vYkRMkqCLpK5u3jxUYtECOWVsYHIHgVlvERV+HWCdyH0PoiEwr97ZU+4mjnc9Av8P7a18Mw==
+  dependencies:
+    "@sentry/hub" "4.5.1"
+    "@sentry/minimal" "4.5.1"
+    "@sentry/types" "4.5.0"
+    "@sentry/utils" "4.5.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-4.5.1.tgz#979c0a826a9abfa567516b0da0e6f4017130def9"
+  integrity sha512-msftpMDSvWaENdYMHX8GPBQ5jTLxClWCprtAlE0AFZ90WHFrwvA0bHpGLzseFDjYwGUKoG2psxejoSstoBy53A==
+  dependencies:
+    "@sentry/types" "4.5.0"
+    "@sentry/utils" "4.5.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-4.5.1.tgz#a6128aab2a3967d8eb99afb3029057e1b4d9aaa5"
+  integrity sha512-/PaBrzuGkL6c137KRz5iIpmIfCj1FY/rYOffBAYrZADmmZyVrHfP2cNreneze+9OYy5dCFylBFEQpNOCMDdARw==
+  dependencies:
+    "@sentry/hub" "4.5.1"
+    "@sentry/types" "4.5.0"
+    tslib "^1.9.3"
+
+"@sentry/node@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-4.5.1.tgz#e8218b952695548d276274d2b6cc4f9d0676e063"
+  integrity sha512-qClDjSvRAAKnXkww5uiXQ+TySHjdmjr3c/scp4QxvjR9tNhYhdfimwdr4ZM6K9jhvK35vKVruuTVFzzSDukWHw==
+  dependencies:
+    "@sentry/core" "4.5.1"
+    "@sentry/hub" "4.5.1"
+    "@sentry/types" "4.5.0"
+    "@sentry/utils" "4.5.1"
+    "@types/stack-trace" "0.0.29"
+    cookie "0.3.1"
+    https-proxy-agent "2.2.1"
+    lru_map "0.3.3"
+    lsmod "1.0.0"
+    stack-trace "0.0.10"
+    tslib "^1.9.3"
+
+"@sentry/types@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.5.0.tgz#59e2a27d48b01b44e8959aa5c8a30514fe1086a9"
+  integrity sha512-IstPjFoebQGrQWdM732D/+S0BTovmDgezyplk4kLEb87+/B+YK0hlhziUa7B2byTFJGgQQKXy7h2sKZBrA3GUA==
+
+"@sentry/utils@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-4.5.1.tgz#23f8a8fbe84e06d2546d3f1a72e30b34cbc2a3d8"
+  integrity sha512-ihzvgKBuvHBjKtbjz3EtuTW0OAJH5nw1L3tNVOCi+fbEdp10DiyL0i3hQKdE87CLoNEAt/SPRmTrG1cP2dNa7Q==
+  dependencies:
+    "@sentry/types" "4.5.0"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -993,6 +1052,11 @@
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-5.0.1.tgz#a15b36ec42f1f53166617491feabd1734cb03e21"
   integrity sha512-yxzBCIjE3lp9lYjfBbIK/LRCoXgCLLbIIBIje7eNCcUIIR2CZZtyX5uto2hVoMSMqLrsRrT6mwwUEd0yFgOwpA==
+
+"@types/stack-trace@0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/stack-trace/-/stack-trace-0.0.29.tgz#eb7a7c60098edb35630ed900742a5ecb20cfcb4d"
+  integrity sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==
 
 "@types/strip-ansi@^3.0.0":
   version "3.0.0"
@@ -10832,6 +10896,16 @@ lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru_map@0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
+
+lsmod@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
+  integrity sha1-mgD3bco26yP6BTUK/htYXUKZ5ks=
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -15411,6 +15485,11 @@ ssri@^5.2.4:
   integrity sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==
   dependencies:
     safe-buffer "^5.1.1"
+
+stack-trace@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stack-utils@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# Description

This PR augments the existing Kibana server initialization to offer a couple startup  hooks — before command line arguments are parsed (w/ ability to modify them), and right before Kibana starts its server.

The "before command line args are parsed" hook is used to initialize Sentry error tracking.