### PR TITLE
1956: Disabled Kibana Suggestions API

### DIFF
--- a/src/core_plugins/kibana/index.js
+++ b/src/core_plugins/kibana/index.js
@@ -26,9 +26,9 @@ import { scrollSearchApi } from './server/routes/api/scroll_search';
 import { importApi } from './server/routes/api/import';
 import { exportApi } from './server/routes/api/export';
 import { homeApi } from './server/routes/api/home';
-import { managementApi } from './server/routes/api/management';
+//import { managementApi } from './server/routes/api/management';
 //import { scriptsApi } from './server/routes/api/scripts';
-import { registerSuggestionsApi } from './server/routes/api/suggestions';
+//import { registerSuggestionsApi } from './server/routes/api/suggestions';
 //import { registerKqlTelemetryApi } from './server/routes/api/kql_telemetry';
 import { registerFieldFormats } from './server/field_formats/register';
 //import { registerTutorials } from './server/tutorials/register';
@@ -167,7 +167,7 @@ export default function (kibana) {
       exportApi(server);
       homeApi(server);
       //managementApi(server);
-      registerSuggestionsApi(server);
+      //registerSuggestionsApi(server);
       //registerKqlTelemetryApi(server);
       registerFieldFormats(server);
       //registerTutorials(server);
@@ -177,4 +177,4 @@ export default function (kibana) {
       server.injectUiAppVars('kibana', () => injectVars(server));
     }
   });
-};
+}


### PR DESCRIPTION
<!--
The template is broken down into sections ( API, UI ).
Keep the ones that are relevant and remove the rest.
-->

# Description

Disables the `registerSuggestionsApi` module in Kibana to prevent auto-complete suggestions from leaking data to which the user should not have access. This is new functionality that was not using our company filter proxy, and should be disabled until it is proven valuable enough to enact the labor to re-enable it with the filter.

Also fixed some things so that ESlint stopped yelling at me.

# 🏁 Ready to Merge checklist

- [x] This branch is code-complete ( no outstanding TODOs )
- [x] I have tested this locally ( and it works )
- [x] All automated tests / linters pass
