### PR TITLE
Suppress toast messages for warnings and errors

### DIFF
--- a/src/core/public/notifications/toasts/toasts_start_contract.tsx
+++ b/src/core/public/notifications/toasts/toasts_start_contract.tsx
@@ -68,18 +68,12 @@ export class ToastsStartContract {
   }
 
   public addWarning(toastOrTitle: ToastInput) {
-    return this.add({
-      color: 'warning',
-      iconType: 'help',
-      ...normalizeToast(toastOrTitle),
-    });
+    // Removed warning toasts per https://github.com/usePF/perchweb/issues/2031
+    return;
   }
 
   public addDanger(toastOrTitle: ToastInput) {
-    return this.add({
-      color: 'danger',
-      iconType: 'alert',
-      ...normalizeToast(toastOrTitle),
-    });
+    // Removed error toasts per https://github.com/usePF/perchweb/issues/2031
+    return;
   }
 }


### PR DESCRIPTION
Closes https://github.com/usePF/perchweb/issues/2031

For purposes of Perchybana; this suppresses toast notifications for warnings and errors thrown by kibana. Success (info) messages will still display as designed.