### PR TITLE
2121 enable reports

### DIFF
--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -105,7 +105,9 @@ logging.verbose: true
 
 # Reporting
 xpack.reporting.enabled: true
-xpack.reporting.encryptionKey: 'abc123'
+xpack.reporting.encryptionKey: "fjklqwe0inqi320n1nv34u0t3"
+xpack.reporting.index: ".reporting-perchybana"
+
 xpack.reporting.csv.maxSizeBytes: 1000000000 #Default is 10MB
 
 

--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -103,11 +103,16 @@ logging.verbose: true
 # translations.
 #i18n.defaultLocale: "en"
 
+# Reporting
+xpack.reporting.enabled: true
+xpack.reporting.encryptionKey: 'abc123'
+xpack.reporting.csv.maxSizeBytes: 1000000000 #Default is 10MB
+
+
 xpack.beats.enabled: false
 xpack.graph.enabled: false
 xpack.ml.enabled: false
 xpack.monitoring.enabled: false
-xpack.reporting.enabled: false
 xpack.watcher.enabled: false
 xpack.security.enabled: false
 #xpack.telemetry.enabled: false
@@ -115,3 +120,4 @@ console.enabled: false
 timelion.enabled: false
 index_management.enabled: false
 license_management.enabled: false
+

--- a/x-pack/plugins/reporting/index.js
+++ b/x-pack/plugins/reporting/index.js
@@ -21,7 +21,8 @@ import { logConfiguration } from './log_configuration';
 import { getReportingUsageCollector } from './server/usage';
 
 /* BEGIN PERCH CODE */
-import { JobsQuery } from "./server/lib/perch_jobs_query";
+import { JobsQuery } from './server/lib/perch_jobs_query';
+import { EnqueueJob } from './server/lib/perch_enqueue_job';
 /* END PERCH CODE */
 
 const kbToBase64Length = (kb) => {
@@ -171,6 +172,7 @@ export const reporting = (kibana) => {
 
       /* BEGIN PERCH CODE */
       server.expose('JobsQuery', JobsQuery);
+      server.expose('EnqueueJob', EnqueueJob);
       /* END PERCH CODE */
 
       // Reporting routes

--- a/x-pack/plugins/reporting/index.js
+++ b/x-pack/plugins/reporting/index.js
@@ -20,6 +20,10 @@ import { logConfiguration } from './log_configuration';
 
 import { getReportingUsageCollector } from './server/usage';
 
+/* BEGIN PERCH CODE */
+import { jobsQueryFactory } from "./server/lib/jobs_query";
+/* END PERCH CODE */
+
 const kbToBase64Length = (kb) => {
   return Math.floor((kb * 1024 * 8) / 6);
 };
@@ -164,6 +168,10 @@ export const reporting = (kibana) => {
 
       server.expose('browserDriverFactory', await createBrowserDriverFactory(server));
       server.expose('queue', createQueueFactory(server));
+
+      /* BEGIN PERCH CODE */
+      server.expose('jobsQueryFactory', jobsQueryFactory);
+      /* END PERCH CODE */
 
       // Reporting routes
       mainRoutes(server);

--- a/x-pack/plugins/reporting/index.js
+++ b/x-pack/plugins/reporting/index.js
@@ -21,7 +21,7 @@ import { logConfiguration } from './log_configuration';
 import { getReportingUsageCollector } from './server/usage';
 
 /* BEGIN PERCH CODE */
-import { jobsQueryFactory } from "./server/lib/jobs_query";
+import { JobsQuery } from "./server/lib/perch_jobs_query";
 /* END PERCH CODE */
 
 const kbToBase64Length = (kb) => {
@@ -170,7 +170,7 @@ export const reporting = (kibana) => {
       server.expose('queue', createQueueFactory(server));
 
       /* BEGIN PERCH CODE */
-      server.expose('jobsQueryFactory', jobsQueryFactory);
+      server.expose('JobsQuery', JobsQuery);
       /* END PERCH CODE */
 
       // Reporting routes

--- a/x-pack/plugins/reporting/public/components/reporting_panel_content.tsx
+++ b/x-pack/plugins/reporting/public/components/reporting_panel_content.tsx
@@ -162,7 +162,7 @@ export class ReportingPanelContent extends Component<Props, State> {
       .then(() => {
         toastNotifications.addSuccess({
           title: `Queued report for ${this.props.objectType}`,
-          text: 'Track its progress in Management',
+          text: 'Track its progress in Reports',
           'data-test-subj': 'queueReportSuccess',
         });
         this.props.onClose();

--- a/x-pack/plugins/reporting/server/lib/enqueue_job.js
+++ b/x-pack/plugins/reporting/server/lib/enqueue_job.js
@@ -14,18 +14,11 @@ function enqueueJobFn(server) {
   const exportTypesRegistry = server.plugins.reporting.exportTypesRegistry;
 
   return async function enqueueJob(exportTypeId, jobParams, user, headers, request) {
-    server.plugins.reporting.queue.index = '.reporthing-hackyhack';
-    console.log('CREATE JOB');
-    console.log(server.options);
-    console.log('PLUGIN');
-    console.log(server.plugins.reporting);
     const exportType = exportTypesRegistry.getById(exportTypeId);
     const createJob = exportType.createJobFactory(server);
 
     const payload = await createJob(jobParams, headers, request);
 
-    console.log('PAYLOAD');
-    console.log(payload);
     const options = {
       timeout: queueConfig.timeout,
       created_by: get(user, 'username', false),

--- a/x-pack/plugins/reporting/server/lib/enqueue_job.js
+++ b/x-pack/plugins/reporting/server/lib/enqueue_job.js
@@ -14,10 +14,18 @@ function enqueueJobFn(server) {
   const exportTypesRegistry = server.plugins.reporting.exportTypesRegistry;
 
   return async function enqueueJob(exportTypeId, jobParams, user, headers, request) {
+    server.plugins.reporting.queue.index = '.reporthing-hackyhack';
+    console.log('CREATE JOB');
+    console.log(server.options);
+    console.log('PLUGIN');
+    console.log(server.plugins.reporting);
     const exportType = exportTypesRegistry.getById(exportTypeId);
     const createJob = exportType.createJobFactory(server);
+
     const payload = await createJob(jobParams, headers, request);
 
+    console.log('PAYLOAD');
+    console.log(payload);
     const options = {
       timeout: queueConfig.timeout,
       created_by: get(user, 'username', false),

--- a/x-pack/plugins/reporting/server/lib/enqueue_job.js
+++ b/x-pack/plugins/reporting/server/lib/enqueue_job.js
@@ -16,7 +16,6 @@ function enqueueJobFn(server) {
   return async function enqueueJob(exportTypeId, jobParams, user, headers, request) {
     const exportType = exportTypesRegistry.getById(exportTypeId);
     const createJob = exportType.createJobFactory(server);
-
     const payload = await createJob(jobParams, headers, request);
 
     const options = {

--- a/x-pack/plugins/reporting/server/lib/perch_enqueue_job.js
+++ b/x-pack/plugins/reporting/server/lib/perch_enqueue_job.js
@@ -21,10 +21,6 @@ EnqueueJob.prototype.getJobQueue = function (index) {
     q = Object.create(q);
     q.index = index;
   }
-  console.log('AFTER');
-  console.log(q.addJob);
-  console.log('REPORTING QUEUE AFTER');
-  console.log(this.server.plugins.reporting.queue.index);
   return q;
 };
 

--- a/x-pack/plugins/reporting/server/lib/perch_enqueue_job.js
+++ b/x-pack/plugins/reporting/server/lib/perch_enqueue_job.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { get } from 'lodash';
+import { events as esqueueEvents } from './esqueue';
+import { oncePerServer } from './once_per_server';
+
+function EnqueueJob(server) {
+  this.queueConfig = server.config().get('xpack.reporting.queue');
+  this.exportTypesRegistry = server.plugins.reporting.exportTypesRegistry;
+  this.jobQueue = server.plugins.reporting.queue;
+  this.server = server;
+}
+
+EnqueueJob.prototype.getJobQueue = function (index) {
+  let q = this.jobQueue;
+  if (index) {
+    q = Object.create(q);
+    q.index = index;
+  }
+  console.log('AFTER');
+  console.log(q.addJob);
+  console.log('REPORTING QUEUE AFTER');
+  console.log(this.server.plugins.reporting.queue.index);
+  return q;
+};
+
+EnqueueJob.prototype.job = async function enqueueJob(exportTypeId, jobParams, user, headers, request, index = null) {
+  const exportType = this.exportTypesRegistry.getById(exportTypeId);
+  const createJob = exportType.createJobFactory(this.server);
+
+  const payload = await createJob(jobParams, headers, request);
+
+  const options = {
+    timeout: this.queueConfig.timeout,
+    created_by: get(user, 'username', false),
+  };
+
+  return new Promise((resolve, reject) => {
+    const jobQueue = this.getJobQueue(index);
+    const job = jobQueue.addJob(exportType.jobType, payload, options);
+
+    job.on(esqueueEvents.EVENT_JOB_CREATED, (createdJob) => {
+      if (createdJob.id === job.id) {
+        this.server.log(['reporting', 'debug'], `Saved object to process`);
+        resolve(job);
+      }
+    });
+    job.on(esqueueEvents.EVENT_JOB_CREATE_ERROR, reject);
+  });
+};
+
+const enqueueJobFactory =  oncePerServer(function (server) {
+  return new EnqueueJob(server);
+});
+
+module.exports = {
+  EnqueueJob,
+  enqueueJobFactory
+};

--- a/x-pack/plugins/reporting/server/lib/perch_jobs_query.js
+++ b/x-pack/plugins/reporting/server/lib/perch_jobs_query.js
@@ -35,7 +35,7 @@ function JobsQuery(server) {
     const query = {
       index: `${index}-*`,
       type: QUEUE_DOCTYPE,
-      body: Object.assign(defaultBody[type] || {}, body)
+      body: { ...defaultBody[type], ...body }
     };
 
     return callWithInternalUser(type, query)
@@ -47,9 +47,7 @@ function JobsQuery(server) {
       });
   };
 
-  this.getHits = (query) => {
-    return query.then((res) => get(res, 'hits.hits', []));
-  };
+  this.getHits = (query) => query.then((res) => get(res, 'hits.hits', []));
 
 }
 
@@ -102,10 +100,7 @@ JobsQuery.prototype.count = function (headers, jobTypes, user, userReportingInde
   };
 
   return this.execQuery('count', body, userReportingIndex)
-    .then((doc) => {
-      if (!doc) return 0;
-      return doc.count;
-    });
+    .then(doc => doc ? doc.count : 0);
 };
 
 JobsQuery.prototype.get = function (headers, user, id, opts = {}, userReportingIndex = null) {
@@ -136,10 +131,7 @@ JobsQuery.prototype.get = function (headers, user, id, opts = {}, userReportingI
   }
 
   return this.getHits(this.execQuery('search', body, userReportingIndex))
-    .then((hits) => {
-      if (hits.length !== 1) return;
-      return hits[0];
-    });
+    .then(hits => hits.length === 1 ? hits[0] : undefined);
 };
 
 const jobsQueryFactory = oncePerServer(server => new JobsQuery(server));

--- a/x-pack/plugins/reporting/server/lib/perch_jobs_query.js
+++ b/x-pack/plugins/reporting/server/lib/perch_jobs_query.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { get } from 'lodash';
+import { QUEUE_DOCTYPE } from '../../common/constants';
+import { oncePerServer } from './once_per_server';
+
+const defaultSize = 10;
+
+function JobsQuery(server) {
+  //const index = server.plugins.reporting.queue.index || server.config().get('xpack.reporting.index');
+  const { callWithInternalUser, errors: esErrors } = server.plugins.elasticsearch.getCluster('admin');
+
+  this.getUsername = (user) => {
+    return get(user, 'username', false);
+  };
+
+  this.execQuery = (type, body) => {
+    const defaultBody = {
+      search: {
+        _source: {
+          excludes: [ 'output.content' ]
+        },
+        sort: [
+          { created_at: { order: 'desc' } }
+        ],
+        size: defaultSize,
+      }
+    };
+
+    const query = {
+      index: `${server.plugins.reporting.queue.index}-*`,
+      type: QUEUE_DOCTYPE,
+      body: Object.assign(defaultBody[type] || {}, body)
+    };
+
+    return callWithInternalUser(type, query)
+      .catch((err) => {
+        if (err instanceof esErrors['401']) return;
+        if (err instanceof esErrors['403']) return;
+        if (err instanceof esErrors['404']) return;
+        throw err;
+      });
+  };
+
+  this.getHits = (query) => {
+    return query.then((res) => get(res, 'hits.hits', []));
+  };
+
+}
+
+
+JobsQuery.prototype.list = function (jobTypes, user, page = 0, size = defaultSize, jobIds) {
+  const username = this.getUsername(user);
+
+  const body = {
+    size,
+    from: size * page,
+    query: {
+      constant_score: {
+        filter: {
+          bool: {
+            must: [
+              { terms: { jobtype: jobTypes } },
+              { term: { created_by: username } },
+            ]
+          }
+        }
+      }
+    },
+  };
+
+  if (jobIds) {
+    body.query.constant_score.filter.bool.must.push({
+      ids: { type: QUEUE_DOCTYPE, values: jobIds }
+    });
+  }
+
+  return this.getHits(this.execQuery('search', body));
+};
+
+JobsQuery.prototype.count = function (jobTypes, user) {
+  const username = this.getUsername(user);
+
+  const body = {
+    query: {
+      constant_score: {
+        filter: {
+          bool: {
+            must: [
+              { terms: { jobtype: jobTypes } },
+              { term: { created_by: username } },
+            ]
+          }
+        }
+      }
+    }
+  };
+
+  return this.execQuery('count', body)
+    .then((doc) => {
+      if (!doc) return 0;
+      return doc.count;
+    });
+};
+
+JobsQuery.prototype.get = function (user, id, opts = {}) {
+  if (!id) return Promise.resolve();
+
+  const username = this.getUsername(user);
+
+  const body = {
+    query: {
+      constant_score: {
+        filter: {
+          bool: {
+            must: [
+              { term: { _id: id } },
+              { term: { created_by: username } }
+            ],
+          }
+        }
+      }
+    },
+    size: 1,
+  };
+
+  if (opts.includeContent) {
+    body._source = {
+      excludes: []
+    };
+  }
+
+  return this.getHits(this.execQuery('search', body))
+    .then((hits) => {
+      if (hits.length !== 1) return;
+      return hits[0];
+    });
+};
+
+const jobsQueryFactory = oncePerServer(server => new JobsQuery(server));
+
+
+module.exports = {
+  JobsQuery,
+  jobsQueryFactory
+};

--- a/x-pack/plugins/reporting/server/routes/jobs.js
+++ b/x-pack/plugins/reporting/server/routes/jobs.js
@@ -40,7 +40,9 @@ export function jobs(server) {
       const size = Math.min(100, parseInt(request.query.size) || 10);
       const jobIds = request.query.ids ? request.query.ids.split(',') : null;
 
+      /* BEGIN PERCH CODE */
       const results = jobsQuery.list(request, request.pre.management.jobTypes, request.pre.user, page, size, jobIds);
+      /* END PERCH CODE */
       reply(results);
     },
     config: getRouteConfig(),
@@ -51,7 +53,9 @@ export function jobs(server) {
     path: `${mainEntry}/count`,
     method: 'GET',
     handler: (request, reply) => {
+      /* BEGIN PERCH CODE */
       const results = jobsQuery.count(request, request.pre.management.jobTypes, request.pre.user);
+      /* END PERCH CODE */
       reply(results);
     },
     config: getRouteConfig(),
@@ -64,7 +68,9 @@ export function jobs(server) {
     handler: (request, reply) => {
       const { docId } = request.params;
 
+      /* BEGIN PERCH CODE */
       jobsQuery.get(request, request.pre.user, docId, { includeContent: true })
+      /* END PERCH CODE */
         .then((doc) => {
           if (!doc) {
             return reply(boom.notFound());

--- a/x-pack/plugins/reporting/server/routes/jobs.js
+++ b/x-pack/plugins/reporting/server/routes/jobs.js
@@ -6,7 +6,7 @@
 
 import boom from 'boom';
 import { API_BASE_URL } from '../../common/constants';
-import { jobsQueryFactory } from '../lib/jobs_query';
+import { jobsQueryFactory } from '../lib/perch_jobs_query';
 import { reportingFeaturePreRoutingFactory } from'../lib/reporting_feature_pre_routing';
 import { authorizedUserPreRoutingFactory } from '../lib/authorized_user_pre_routing';
 import { jobResponseHandlerFactory } from '../lib/job_response_handler';

--- a/x-pack/plugins/reporting/server/routes/jobs.js
+++ b/x-pack/plugins/reporting/server/routes/jobs.js
@@ -40,7 +40,7 @@ export function jobs(server) {
       const size = Math.min(100, parseInt(request.query.size) || 10);
       const jobIds = request.query.ids ? request.query.ids.split(',') : null;
 
-      const results = jobsQuery.list(request.pre.management.jobTypes, request.pre.user, page, size, jobIds);
+      const results = jobsQuery.list(request, request.pre.management.jobTypes, request.pre.user, page, size, jobIds);
       reply(results);
     },
     config: getRouteConfig(),
@@ -51,7 +51,7 @@ export function jobs(server) {
     path: `${mainEntry}/count`,
     method: 'GET',
     handler: (request, reply) => {
-      const results = jobsQuery.count(request.pre.management.jobTypes, request.pre.user);
+      const results = jobsQuery.count(request, request.pre.management.jobTypes, request.pre.user);
       reply(results);
     },
     config: getRouteConfig(),
@@ -64,7 +64,7 @@ export function jobs(server) {
     handler: (request, reply) => {
       const { docId } = request.params;
 
-      jobsQuery.get(request.pre.user, docId, { includeContent: true })
+      jobsQuery.get(request, request.pre.user, docId, { includeContent: true })
         .then((doc) => {
           if (!doc) {
             return reply(boom.notFound());

--- a/x-pack/plugins/reporting/server/routes/main.js
+++ b/x-pack/plugins/reporting/server/routes/main.js
@@ -6,7 +6,7 @@
 
 import boom from 'boom';
 import { API_BASE_URL } from '../../common/constants';
-import { enqueueJobFactory } from '../lib/enqueue_job';
+import { enqueueJobFactory } from '../lib/perch_enqueue_job';
 import { reportingFeaturePreRoutingFactory } from '../lib/reporting_feature_pre_routing';
 import { authorizedUserPreRoutingFactory } from '../lib/authorized_user_pre_routing';
 import rison from 'rison-node';
@@ -112,7 +112,11 @@ export function main(server) {
     const user = request.pre.user;
     const headers = request.headers;
 
+    /* BEGIN PERCH CODE
     const job = await enqueueJob(exportTypeId, jobParams, user, headers, request);
+    */
+    const job = await enqueueJob.job(exportTypeId, jobParams, user, headers, request);
+    /* END PERCH CODE */
 
     // return the queue's job information
     const jobJson = job.toJSON();


### PR DESCRIPTION
Description:
Kibana code had to be modified to allow us to hook into functions that create jobs and retrieve reports so that we can dynamically set the reports index and inject an index per user.

Major Modifications:
- Two files were completely rewritten where I created compatible classes that allow us to expose and modify the methods from the perch_plugin
- perch_enqueue_job.js
  - `EnqueueJobs` was converted to a class so that the `job` method could be exposed to the perch_plugin system. This method is then overridden in perch_plugin where a request is made to the perchweb api and the retrieved `user.id` is used to build a per-user reports index. The per user reports index is then passed into the original `job` method where it gets picked up and used to save the report job to that users' index.
- perch_jobs_query.js
  - `JobsQuery` was converted to a class so that the `list`, `count`,  and `get` functions could be exposed to the perch_plugin system. These methods are then overridden in perch_plugin where a request is made to the perchweb api and the retrieved `user.id` is used to build a per-user reports index. The per user reports index is then passed into the original method and used to retrieve the reports.

Demo:
https://www.dropbox.com/s/bkq826m9leywtul/perchybana_reporting.mov?dl=0